### PR TITLE
Fix markdown matches.

### DIFF
--- a/autoload/precious/matcher/context_blocks.vim
+++ b/autoload/precious/matcher/context_blocks.vim
@@ -75,7 +75,7 @@ let s:context_blocks = {
 \		}
 \	],
 \	'markdown': [
-\		{"start" : '^\s*```s*\(\h\w*\)', "end" : '^```$', "filetype" : '\1'},
+\		{"start" : '^\s*```\s*\(\h\w*\)', "end" : '^\s*```$', "filetype" : '\1'},
 \	],
 \}
 


### PR DESCRIPTION
```shell で `filetype=hell` になっていたのと、endを認識できずに最後までfiletypeが変わったままなのを修正しました
(そもそも↑が `sh` じゃなく `shell` となっていたのが自分のミスなのは気にしない方向で)

---

あと個人的に気になってるのがhelpの定義がそこらじゅうで誤爆して大暴走してしまっているのが気になってたりします
( `^>` が記述されているが、endにあたる `^<` が無い箇所がたくさんある)
