### PR TITLE
fix typos

### DIFF
--- a/doc/precious.jax
+++ b/doc/precious.jax
@@ -93,7 +93,7 @@ Example: >
 	augroup END
 <
 
-PreciousFiletype_{filetype}			*PreciousFileType_*
+PreciousFileType_{filetype}			*PreciousFileType_*
 	{filetype} のコンテキストへ切り替わった時に呼ばれます。
 
 Example: >
@@ -102,7 +102,7 @@ Example: >
 		" ruby のコンテキストに入った時、tabstop=8 を設定する
 		" :PreciousSetContextLocal を使用することで
 		" ruby のコンテキストを抜けると元の値に戻すことが出来る
-		autocmd User PreciousFiletype_ruby :PreciousSetContextLocal tabstop=8
+		autocmd User PreciousFileType_ruby :PreciousSetContextLocal tabstop=8
 	augroup END
 <
 
@@ -273,7 +273,7 @@ let g:precious_enable_switchers = {
 " コンテキストが切り替わった場合、syntax を設定
 augroup test
 	autocmd!
-	autocmd User PreciousFiletype let &l:syntax = precious#context_filetype()
+	autocmd User PreciousFileType let &l:syntax = precious#context_filetype()
 augroup END
 <
 


### PR DESCRIPTION
autocmd_context_filetype.vim をみると Type は大文字が正しいように見えました。

http://d.hatena.ne.jp/osyo-manga/20130612/1371046408
ここも type と小文字になっている部分が何か所かあります。
