### PR TITLE
Fix autocmd event CursorMovedI.

### DIFF
--- a/plugin/precious.vim
+++ b/plugin/precious.vim
@@ -52,8 +52,8 @@ augroup precious-augroup
 \|			PreciousSwitchAutcmd
 \|		endif
 
-	autocmd CursorMoved *
-\		if s:is_enable_switch_CursorMoved(precious#base_filetype())
+	autocmd CursorMovedI *
+\		if s:is_enable_switch_CursorMoved_i(precious#base_filetype())
 \		&& get(b:, "precious_switch_lock", 0) == 0
 \|			PreciousSwitchAutcmd
 \|		endif


### PR DESCRIPTION
CursorMovedI が登録されておらず、CursorMoved が2回登録されていました。