### PR TITLE
Enable partial wildcard.

### DIFF
--- a/plugin/precious.vim
+++ b/plugin/precious.vim
@@ -22,23 +22,17 @@ let g:precious_enable_switch_CursorHold
 
 
 function! s:is_enable_switch_CursorMoved(filetype)
-	return (get(g:precious_enable_switch_CursorMoved, "*", 1)
-\		 || get(g:precious_enable_switch_CursorMoved, a:filetype, 0))
-\		 && get(g:precious_enable_switch_CursorMoved, a:filetype, 1)
+  return precious#switch_def(g:precious_enable_switch_CursorMoved, a:filetype, 1)
 endfunction
 
 
 function! s:is_enable_switch_CursorMoved_i(filetype)
-	return (get(g:precious_enable_switch_CursorMoved_i, "*", 1)
-\		 || get(g:precious_enable_switch_CursorMoved_i, a:filetype, 0))
-\		 && get(g:precious_enable_switch_CursorMoved_i, a:filetype, 1)
+	return precious#switch_def(g:precious_enable_switch_CursorMoved_i, a:filetype, 1)
 endfunction
 
 
 function! s:is_enable_switch_CursorHold(filetype)
-	return (get(g:precious_enable_switch_CursorHold, "*", 1)
-\		 || get(g:precious_enable_switch_CursorHold, a:filetype, 0))
-\		 && get(g:precious_enable_switch_CursorHold, a:filetype, 1)
+	return precious#switch_def(g:precious_enable_switch_CursorHold, a:filetype, 1)
 endfunction
 
 


### PR DESCRIPTION
`g:precious_enable_switchers` 等の *key* に fileglob ライクな指定を可能にします。
複数マッチする場合、`strlen()` で最長の *key* が選択されます。

```vim
let g:precious_enable_switchers = {
\  '*html': { 'setfiletype': 0 },  " => html, xhtml
\  'ref-p[yh]*': { 'setfiletype': 0 },  " => ref-pydoc, ref-phpmanual
\}
```